### PR TITLE
New build for linux + typo and build instructions fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ If you want to build manually on a Ubuntu/Debian-based machine, please follow th
 ```
 sudo apt install golang-go
 cd klaunch
-go build
+go build -o klaunch_linux
 ```
 
-Steps may vary on other distributions install process like `sudo dnf install golang` or `sudo pacman -S go` but usually installing the standard Go compiled, linked and stdlib is enough.
+Steps may vary on other distributions install process like `sudo dnf install golang` or `sudo pacman -S go` but usually installing the standard Go compiler, linked and stdlib is enough.
 
 ##  Commands
 


### PR DESCRIPTION
Self-explanatory title: New Linux build on file `klaunch_linux` + fixed typo and build instructions so the build output does not overwrite the macOS build. 